### PR TITLE
bin/tcr: add script for test && commit || revert workflow

### DIFF
--- a/bin/tcr
+++ b/bin/tcr
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if ./test.sh "$1"; then
+  git add -A
+  git commit -am 'tests pass'
+else
+  git reset --hard
+fi

--- a/dotfiles/editor/vimrc
+++ b/dotfiles/editor/vimrc
@@ -104,6 +104,9 @@ nnoremap <silent> <Leader>t :TestFile<CR>
 nnoremap <silent> <Leader>s :TestNearest<CR>
 nnoremap <silent> <Leader>l :TestLast<CR>
 
+" Test && Commit || Revert
+nnoremap <buffer> <Leader>c :!clear && tcr %<CR>
+
 " Treat <li> and <p> tags like the block tags they are
 let g:html_indent_tags = 'li\|p'
 


### PR DESCRIPTION
Theory: Make small steps.

Versus TDD: No "constant not found" / "method not found".
Have to write fakes in same commit.

Tooling: Unlike format-on-save tools,
want to see test output / backtrace on failure.

Assume a `./tesh.sh` file in the project directory
where Vim is opened.
Trigger `test && commit || revert` with `<Leader>c` for now.

Taking it to the extreme:

* Each team member works directly on `master` in the codebase
* No feature branches
* No pull requests
* No code review
* `test && commit || revert` on file save
* A loop on each person's machine
  `git pull --rebase && git push`

Alternative tooling ideas:

Use <https://github.com/janko-m/vim-test> (already installed).
Override current commands:

```
<Leader>t :TestFile<CR>
<Leader>s :TestNearest<CR>
<Leader>l :TestLast<CR>
```

With something that runs those more-focused tests,
commits with messages like `pass: spec/models/user_spec.rb`
or `pass: AdminPayment#validate crypto transaction ID`,
or reverts.