### PR TITLE
laptop.sh: install Go 1.13

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -153,7 +153,7 @@ asdf_plugin_update() {
 }
 
 # Go
-gover="1.12.9"
+gover="1.13"
 if ! go version | grep -Fq "$gover"; then
   sudo rm -rf /usr/local/go
   curl "https://dl.google.com/go/go$gover.darwin-amd64.tar.gz" | \


### PR DESCRIPTION
Before:

```
% go version
go version go1.12.9 darwin/amd64
```

After `$OK/laptop.sh`:

```
% go version
go version go1.13 darwin/amd64
```

https://golang.org/doc/go1.3