### PR TITLE
dotfiles/shell/kitty.conf: add tab navigation maps

### DIFF
--- a/dotfiles/shell/kitty.conf
+++ b/dotfiles/shell/kitty.conf
@@ -1,16 +1,34 @@
 # vim:fileencoding=utf-8:ft=conf
 
+# color
 background #ffffff
 cursor #cccccc
-font_family Monaco
-font_size 14.0
 foreground #000000
 
-#: remap font resizing keys to allow <c-_><c-_> to run :TComment in Vim
+# font
+font_family Monaco
+font_size 14.0
+map cmd+equal change_font_size all +2.0
+map cmd+minus change_font_size all -2.0
+
+#: allow <c-_><c-_> to run :TComment in Vim
 #: https://github.com/tomtom/tcomment_vim
 map ctrl+shift+equal no_op
 map ctrl+shift+minus no_op
-map cmd+equal        change_font_size all +2.0
-map cmd+minus        change_font_size all -2.0
 
+# clear
 map cmd+k combine : clear_terminal scrollback active : send_text normal \x0c
+
+# tabs
+map super+shift+[ previous_tab
+map super+shift+] next_tab
+map super+1 goto_tab 1
+map super+2 goto_tab 2
+map super+3 goto_tab 3
+map super+4 goto_tab 4
+map super+5 goto_tab 5
+map super+6 goto_tab 6
+map super+7 goto_tab 7
+map super+8 goto_tab 8
+map super+9 goto_tab 9
+map super+0 goto_tab 10


### PR DESCRIPTION
Cycle through tabs like Chrome.
Go to tabs by number like Chrome.

Re-organize sections with comments.