### PR TITLE
all: install and use SF Mono font

### DIFF
--- a/dotfiles/shell/kitty.conf
+++ b/dotfiles/shell/kitty.conf
@@ -6,8 +6,9 @@ cursor #cccccc
 foreground #000000
 
 # font
-font_family Monaco
-font_size 14.0
+font_family SFMono-Regular
+font_size 15.0
+adjust_line_height 120%
 map cmd+equal change_font_size all +2.0
 map cmd+minus change_font_size all -2.0
 

--- a/laptop.sh
+++ b/laptop.sh
@@ -171,3 +171,8 @@ npm config set scripts-prepend-node-path true
 # Ruby
 asdf_plugin_update "ruby" "https://github.com/asdf-vm/asdf-ruby"
 asdf install ruby 2.6.1
+
+# SF Mono
+if ! echo ~/Library/Fonts/SFMono* > /dev/null; then
+  cp -R /Applications/Utilities/Terminal.app/Contents/Resources/Fonts/. ~/Library/Fonts/
+fi


### PR DESCRIPTION
This is the same font used in Xcode and GitHub's file viewer.
https://developer.apple.com/fonts/