### PR TITLE
laptop.sh: don't write Homebrew lockfile

### DIFF
--- a/laptop.sh
+++ b/laptop.sh
@@ -52,8 +52,8 @@ if ! command -v brew >/dev/null; then
 fi
 
 brew analytics off
-brew update
-brew bundle --file=- <<EOF
+brew update-reset
+brew bundle --no-lock --file=- <<EOF
 tap "heroku/brew"
 tap "homebrew/services"
 


### PR DESCRIPTION
Running without this flag is throwing a warning.

Also fetch and reset Homebrew and all tap repos
to their latest `origin/master`.