### PR TITLE
all: use Postgres.app instead of Homebrew Postgres

### DIFF
--- a/dotfiles/shell/zshrc
+++ b/dotfiles/shell/zshrc
@@ -114,6 +114,9 @@ PATH="$HOME/.asdf/shims:$PATH"
 # Prepend Go binaries
 PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
+# Prepend Postgres.app tools
+PATH="/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH"
+
 # Prepend monorepo scripts
 PATH="$OK/bin:$PATH"
 PATH="$POGO/bin:$PATH"

--- a/laptop.sh
+++ b/laptop.sh
@@ -68,7 +68,6 @@ brew "imagemagick@6"
 brew "jq"
 brew "libyaml"
 brew "openssl"
-brew "postgresql", restart_service: :changed
 brew "protobuf"
 brew "r"
 brew "reattach-to-user-namespace"


### PR DESCRIPTION
Homebrew Postgres does not follow the Postgres convention of
creating a `postgres` user who own system tables like `pg_catalog`.
Some tools depend on this structure.
Postgres.app does the conventional thing as expected.

Postgres.app also allows having multiple versions installed at the same
time so I can use version 11.6 (to match current Heroku Postgres)
and version 12 (to test my software against next version).