### PR TITLE
dotfiles/vim/go: remove unused config, use new linter

### DIFF
--- a/dotfiles/editor/vim/ftplugin/go.vim
+++ b/dotfiles/editor/vim/ftplugin/go.vim
@@ -1,6 +1,8 @@
 " $OK/bin/goimportslocal
 let g:go_fmt_command = "goimportslocal"
 
+let b:ale_linters = ['gopls']
+
 setlocal listchars=tab:\ \ ,trail:·,nbsp:·
 setlocal noexpandtab
 
@@ -17,33 +19,6 @@ nmap <buffer> <Leader>t <Plug>(go-test)
 
 " Run test for specific function under cursor
 nmap <buffer> <Leader>s <Plug>(go-test-func)
-
-" Rename the identifier under cursor
-nmap <buffer> <Leader>re <Plug>(go-rename)
-
-" Toggle test coverage
-nmap <buffer> <Leader>c <Plug>(go-coverage-toggle)
-
-" Open definition in a vertical split
-nmap <buffer> <Leader>d <Plug>(go-def-vertical)
-
-" List interfaces for the type under cursor
-nmap <buffer> <Leader>i <Plug>(go-implements)
-
-" Run :GoBuild or :GoTestCompile based on the file
-function! s:build_go_files()
-  let l:file = expand('%')
-  if l:file =~# '^\f\+_test\.go$'
-    call go#cmd#Test(0, 1)
-  elseif l:file =~# '^\f\+\.go$'
-    call go#cmd#Build(0)
-  endif
-endfunction
-
-autocmd FileType go nmap <leader>b :<C-u>call <SID>build_go_files()<CR>
-
-" Use godef instead of guru
-let g:go_def_mode = 'godef'
 
 " Syntax highlight additional tokens
 let g:go_highlight_fields = 1


### PR DESCRIPTION
Open ALE drawer when there are linting issues.

https://github.com/dense-analysis/ale/blob/master/ale_linters/go/gopls.vim