### PR TITLE
dotfiles/vim: fix TypeScript React syntax highlighting

### DIFF
--- a/dotfiles/editor/vim/syntax/typescriptreact.vim
+++ b/dotfiles/editor/vim/syntax/typescriptreact.vim
@@ -1,0 +1,1 @@
+runtime! syntax/typescript.vim

--- a/laptop.sh
+++ b/laptop.sh
@@ -98,9 +98,10 @@ brew cleanup
 
   mkdir -p "$HOME/.vim/ftdetect"
   mkdir -p "$HOME/.vim/ftplugin"
+  mkdir -p "$HOME/.vim/syntax"
   (
     cd editor/vim
-    for f in {ftdetect,ftplugin}/*; do
+    for f in {ftdetect,ftplugin,syntax}/*; do
       ln -sf "$PWD/$f" "$HOME/.vim/$f"
     done
   )


### PR DESCRIPTION
There is a `typescriptreact` filetype in new versions of Vim.
The `typescript-vim` plugin isn't totally up to date with this version.
Without this change, my syntax highlighting becomes a carnival.
Keep things quieter.