### PR TITLE
dotfiles/shell/ssh: remove RSA reference

### DIFF
--- a/dotfiles/shell/ssh
+++ b/dotfiles/shell/ssh
@@ -1,7 +1,6 @@
 Host *
   AddKeysToAgent yes
   UseKeychain yes
-  IdentityFile ~/.ssh/id_rsa
   IdentityFile ~/.ssh/id_ed25519
 
 Host github.com


### PR DESCRIPTION
I'm using only ed25519 keys these days.

https://medium.com/risan/upgrade-your-ssh-key-to-ed25519-c6e8d60d3c54